### PR TITLE
Fixes to frontend telemetry error handling and adding sourcemaps

### DIFF
--- a/src/frontend/gateways/Session.gateway.ts
+++ b/src/frontend/gateways/Session.gateway.ts
@@ -17,16 +17,16 @@ const defaultSession = {
 const SessionGateway = () => ({
   getSession(): ISession {
     if (typeof window === 'undefined') return defaultSession;
-    const sessionString = localStorage.getItem(sessionKey);
+    const sessionString = sessionStorage.getItem(sessionKey);
 
-    if (!sessionString) localStorage.setItem(sessionKey, JSON.stringify(defaultSession));
+    if (!sessionString) sessionStorage.setItem(sessionKey, JSON.stringify(defaultSession));
 
     return JSON.parse(sessionString || JSON.stringify(defaultSession)) as ISession;
   },
   setSessionValue<K extends keyof ISession>(key: K, value: ISession[K]) {
     const session = this.getSession();
 
-    localStorage.setItem(sessionKey, JSON.stringify({ ...session, [key]: value }));
+    sessionStorage.setItem(sessionKey, JSON.stringify({ ...session, [key]: value }));
   },
 });
 

--- a/src/frontend/next.config.js
+++ b/src/frontend/next.config.js
@@ -28,6 +28,7 @@ const {
 
 const nextConfig = {
   reactStrictMode: true,
+  productionBrowserSourceMaps: true,
   output: 'standalone',
   compiler: {
     styledComponents: true,

--- a/src/frontend/utils/telemetry/HoneycombFrontendTracer.ts
+++ b/src/frontend/utils/telemetry/HoneycombFrontendTracer.ts
@@ -38,11 +38,12 @@ const HoneycombFrontendTracer = (sessionId: string) => {
         }),
         instrumentations: [
             getWebAutoInstrumentations({
-              // turn on networkEvents so we can see data for resourceFetch content sizes
-              '@opentelemetry/instrumentation-document-load': { ...configDefaults, ignoreNetworkEvents: false },
+              // alternative: turn on networkEvents so we can see data for resourceFetch content sizes
+              //'@opentelemetry/instrumentation-document-load': { ...configDefaults, ignoreNetworkEvents: false },
+              '@opentelemetry/instrumentation-document-load': configDefaults,
                 '@opentelemetry/instrumentation-fetch': {
-                    propagateTraceHeaderCorsUrls: /.*/,
-                    clearTimingResources: true,
+                  ...configDefaults,
+                    // clearTimingResources: true,
                     applyCustomAttributesOnSpan(span) {
                         span.setAttribute('app.synthetic_request', IS_SYNTHETIC_REQUEST);
                     },
@@ -54,17 +55,17 @@ const HoneycombFrontendTracer = (sessionId: string) => {
                 }
             }),
         ],
-        webVitalsInstrumentationConfig: {
-          cls: {
-            reportAllChanges: true
-          },
-          lcp: {
-            reportAllChanges: true
-          },
-          inp: {
-            reportAllChanges: true
-          }
-        },
+        // webVitalsInstrumentationConfig: {
+        //   cls: {
+        //     reportAllChanges: true
+        //   },
+        //   lcp: {
+        //     reportAllChanges: true
+        //   },
+        //   inp: {
+        //     reportAllChanges: true
+        //   }
+        // },
         sessionProvider: {
             getSessionId: () => sessionId
         }


### PR DESCRIPTION
# Changes

1. session gateway should store session id in sessionStorage, not localStorage, so each tab can have its own session, and it expires automatically. Fixed in SessionGateway
2. Turned on sourcemap generation. 
3. Fixed error handling utils in frontend to properly add the span event for the error, record the exception, then set the span status to error.  The order was wrong.
4. Removed inconsistent settings for instrumentation, including disabling network spans.
5. Removed some settings I was trying with Core Web Vitals 
6. Removed a few places where I set the span status to OK, which should not be done.
Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
