### PR TITLE
fix/apply-env-to-right-container

### DIFF
--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -12683,7 +12683,7 @@ spec:
             - containerPort: 6379
               name: valkey-cart
           env:
-           - name: OTEL_SERVICE_NAME
+            - name: OTEL_SERVICE_NAME
               valueFrom:
                 fieldRef:
                   apiVersion: v1


### PR DESCRIPTION
the ENV_PLATFORM var was applied to the wrong container in my original fix.

# Changes

Moved ENV_PLATFORM setting to the frontend pod config for prod.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
