### PR TITLE
fix platform tag component to always use NEXT env var

### DIFF
--- a/notes/ACTIVE.md
+++ b/notes/ACTIVE.md
@@ -3,8 +3,43 @@
 This file is for active work. Put output and plans here.
 When you complete an item, test it! then check it off here and then make a commit.
 
-## what are we working on?
+## Fixed React Hydration Error in PlatformFlag Component
 
-Seeing some error logs from the app when error_customer.py is run
+### Problem
+The Next.js frontend was experiencing React hydration errors in production due to inconsistent client/server rendering in the `PlatformFlag` component.
 
-Currently it might be a deploy problem. Let's teach Claude how to deploy this.
+### Root Cause Analysis
+- **Development/Local**: Uses `envOverrides` in `demo-values.yaml` to set `ENV_PLATFORM=local` globally
+- **Production**: Sets `ENV_PLATFORM=production` directly in kubernetes deployment manifest 
+
+The hydration error occurred because:
+1. Server-side rendering used `process.env.NEXT_PUBLIC_PLATFORM` (from `ENV_PLATFORM` via `next.config.js`)  
+2. Client-side rendering tried to access `window.ENV.NEXT_PUBLIC_PLATFORM` (injected via script in `_document.tsx`)
+3. This created a timing mismatch causing hydration errors
+
+### Solution Applied
+Fixed `src/frontend/components/PlatformFlag/PlatformFlag.tsx` to use consistent environment variable access:
+
+**Before:**
+```typescript
+const { NEXT_PUBLIC_PLATFORM = 'local' } = typeof window !== 'undefined' ? window.ENV : {};
+const platform = NEXT_PUBLIC_PLATFORM;
+```
+
+**After:**
+```typescript
+const platform = process.env.NEXT_PUBLIC_PLATFORM || 'local';
+```
+
+### Key Benefits
+- ✅ Eliminates server/client hydration mismatch
+- ✅ Uses Next.js built-in environment variable handling
+- ✅ Works consistently in both development and production
+- ✅ Simpler, more reliable code
+
+### Files Modified
+- `src/frontend/components/PlatformFlag/PlatformFlag.tsx` - Fixed environment variable access
+
+### Testing Status
+- ✅ Build passes successfully
+- 🔄 User will test deployment to verify fix resolves production hydration errors

--- a/src/frontend/components/PlatformFlag/PlatformFlag.tsx
+++ b/src/frontend/components/PlatformFlag/PlatformFlag.tsx
@@ -3,9 +3,7 @@
 
 import * as S from './PlatformFlag.styled';
 
-const { NEXT_PUBLIC_PLATFORM = 'local' } = typeof window !== 'undefined' ? window.ENV : {};
-
-const platform = NEXT_PUBLIC_PLATFORM;
+const platform = process.env.NEXT_PUBLIC_PLATFORM || 'local';
 
 const PlatformFlag = () => {
   return (


### PR DESCRIPTION
# Changes

Correct the platform tag to not look at window.env and to look at the same place for both prod and local dev. Hopefully.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
