### PR TITLE
remove Image tag and replace with img to fix cart icon across proxy

### DIFF
--- a/src/frontend/components/CartIcon/CartIcon.styled.ts
+++ b/src/frontend/components/CartIcon/CartIcon.styled.ts
@@ -1,12 +1,13 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import Image from 'next/image';
+// Ken Rimple - Next.js Image tag breaks proxy URLs with Kubernetes
+// so I've disabled that here
+// import Image from 'next/image';
 import styled from 'styled-components';
 
 export const CartIcon = styled.a`
   position: relative;
-  display: block;
   margin-left: 25px;
   display: flex;
   flex-flow: column;
@@ -15,7 +16,7 @@ export const CartIcon = styled.a`
   cursor: pointer;
 `;
 
-export const Icon = styled(Image).attrs({
+export const Icon = styled.img.attrs({
   width: '24',
   height: '24',
 })`


### PR DESCRIPTION
# Changes

The Cart icon in the frontend is broken in zurelia and in our own dev environments. After researching a bit it looks like the `next/image` component may be rewriting it to pay attention to the X-Forwarded-Host header, which points to localhost:8080, not the production URL for Zurelia or the localhost:9191 host for local dev.

There _may_ be a better way to solve this with configuration? so this may be a temporary fix.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
