### PR TITLE
fix - now properly adds path to map file

### DIFF
--- a/src/frontend/next.config.js
+++ b/src/frontend/next.config.js
@@ -33,15 +33,22 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
-  webpack: (config, { isServer }) => {
-    if (!isServer) {
+  webpack: (config, { isServer, dev: isDev, webpack }) => {
+    if (!isServer && !isDev) {
       config.resolve.fallback.http2 = false;
       config.resolve.fallback.tls = false;
       config.resolve.fallback.net = false;
       config.resolve.fallback.dns = false;
       config.resolve.fallback.fs = false;
+      config.devtool = false; // disable defaults
+      config.plugins.push(
+        new webpack.SourceMapDevToolPlugin({
+          filename: '[file].map',
+          test: /\.(m?js)($|\?)/i,
+          append: '\n//# sourceMappingURL=/_next/static/chunks/[url]'
+        })
+      );
     }
-
     return config;
   },
   env: {


### PR DESCRIPTION
# Changes

Added configuration to `src/frontend/next.config.ts` to put the proper static file plath for map files, so they can be discovered next to their minified js files for production Next.js in the frontend.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
