### PR TITLE
fix/nginx buffer settings to stop Android OKHTTP Cancels

### DIFF
--- a/src/image-provider/nginx.conf.template
+++ b/src/image-provider/nginx.conf.template
@@ -26,6 +26,10 @@ http {
         server_name _;
         server_tokens off;
 
+        // KJR Honeycomb: this stops the stream was reset: CANCEL errors on Android
+        proxy_redirect off;
+        proxy_buffering off;
+
         root /static;
         gzip_static on;
     }


### PR DESCRIPTION
# Changes

Modifications to the image-provider's nginx conf file to avoid buffering output for images. This has been causing CANCEL errors with android okhttp requests, resulting in extra calls. According to https://stackoverflow.com/questions/65137191/okhttp-keeps-getting-streamresetexception-stream-was-reset-internal-error-when the fix was this small change to the nginx conf file. I tried it and didn't get the CANCEL errors on my deployment. Am going to try to push this to see if it fixes it in devrel prod. Will back out if necessary.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
