### PR TITLE
fix/flagd-is-a-giant-footgun

### DIFF
--- a/scripts/patch-flagd-config.sh
+++ b/scripts/patch-flagd-config.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e
+
+NAMESPACE="${1:-$USER-local}"
+FLAG_KEY="cartservice.add-db-call"
+
+echo "Checking flagd-config in namespace '$NAMESPACE' for flag '$FLAG_KEY'..."
+
+CURRENT_JSON=$(kubectl get configmap flagd-config -n "$NAMESPACE" -o jsonpath='{.data.demo\.flagd\.json}')
+
+if echo "$CURRENT_JSON" | jq -e ".flags[\"$FLAG_KEY\"]" > /dev/null 2>&1; then
+  echo "Flag '$FLAG_KEY' already exists. Skipping."
+  exit 0
+fi
+
+echo "Adding flag '$FLAG_KEY'..."
+UPDATED_JSON=$(echo "$CURRENT_JSON" | jq --arg key "$FLAG_KEY" '.flags[$key] = {
+  "description": "Add a DB call to the cart service",
+  "state": "ENABLED",
+  "variants": { "on": true, "off": false },
+  "defaultVariant": "off"
+}')
+
+kubectl get configmap flagd-config -n "$NAMESPACE" -o json \
+  | jq --arg json "$UPDATED_JSON" '.data["demo.flagd.json"] = $json' \
+  | kubectl apply --server-side --force-conflicts --field-manager='helm' -f -
+
+echo "Restarting flagd to pick up new config..."
+kubectl rollout restart deployment flagd -n "$NAMESPACE"
+kubectl rollout status deployment flagd -n "$NAMESPACE" --timeout=60s
+
+echo "Done. Flag '$FLAG_KEY' added to flagd-config."

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -236,3 +236,6 @@ deploy:
               - "./scripts/setup-pod-identity-association.sh"
               - "--namespace"
               - "$USER-local"
+        - host:
+            command:
+              - "./scripts/patch-flagd-config.sh"


### PR DESCRIPTION
May I just say, I hate manually patching flagd with configmap in k9s.

So, I asked Claude to figure this out. This is a >>> COMPLETE HACK <<<<<

There. I've said it.

What Claude does is patch the configmap with jq on deploy. It does this each ./run cycle, and running it twice doesn't add a second one. This is good until we can get our own feature flagging that doesn't rely on upstream.

# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
