### PR TITLE
storechat: shape GenAI telemetry to the latest OTel semconv

### DIFF
--- a/deploy/config-files/collector/values-daemonset.yaml
+++ b/deploy/config-files/collector/values-daemonset.yaml
@@ -222,23 +222,25 @@ config:
 
     # ── GenAI span shaping ──────────────────────────────────────────────
     # Strands (storechat) and product-reviews emit GenAI telemetry that needs
-    # shaping before it's useful in Honeycomb. Split into three small
-    # processors so each job is self-contained:
-    #   1. genai_copy_events_to_span      — promote Strands' span-EVENT
-    #      attributes onto the parent span. Pure copy, no math.
-    #   2. genai_canonicalize_token_names — rename cache attributes to the
-    #      semconv 1.41 canonical dotted form (covers both sources).
-    #   3. genai_fix_token_counts         — reconstruct semconv-correct token
-    #      counts (input_tokens must include cached tokens).
-
-    # 1. COPY TO SPAN — Strands emits messages + usage on a
-    #    `gen_ai.client.inference.operation.details` span event; copy each
-    #    attribute up to the span verbatim so downstream reads them as span
-    #    attributes. product-reviews already sets these directly on the span,
-    #    so it skips this step and is handled entirely by (2).
-    transform/genai_copy_events_to_span:
+    # shaping before it's useful in Honeycomb. One processor, staged
+    # statement groups that run in order:
+    #   1. COPY TO SPAN          — promote Strands' span-EVENT attributes
+    #      onto the parent span. Pure copy, no math.
+    #   2. CANONICALISE NAMES    — rename cache attributes to the semconv
+    #      1.41 canonical dotted form (covers both sources).
+    #   3. FIX TOKEN COUNTS      — reconstruct semconv-correct token counts
+    #      (input_tokens must include cached tokens).
+    #   4. STRANDS SEMCONV SHAPE — per-operation attribute placement for
+    #      Strands spans per the latest GenAI semconv tables.
+    transform/genai_semconv:
         error_mode: ignore
         trace_statements:
+            # 1. COPY TO SPAN — Strands emits messages + usage on a
+            #    `gen_ai.client.inference.operation.details` span event; copy
+            #    each attribute up to the span verbatim so downstream reads
+            #    them as span attributes. product-reviews already sets these
+            #    directly on the span, so it skips this step and is handled
+            #    entirely by (2).
             - context: spanevent
               conditions:
                   - IsMatch(name, "^gen_ai\\..*")
@@ -257,14 +259,12 @@ config:
                   - set(span.attributes["gen_ai.request.model"], attributes["gen_ai.request.model"]) where attributes["gen_ai.request.model"] != nil
                   - set(span.attributes["gen_ai.operation.name"], attributes["gen_ai.operation.name"]) where attributes["gen_ai.operation.name"] != nil
 
-    # 2. CANONICALISE TOKEN NAMES — rename cache attributes to the semconv 1.41
-    #    canonical dotted form. Runs at span level (not in the copy step)
-    #    because product-reviews sets a non-canonical cache_write.input_tokens
-    #    directly on the span and never passes through copy; handling it here in
-    #    one place covers that and Strands' promoted underscore names alike.
-    transform/genai_canonicalize_token_names:
-        error_mode: ignore
-        trace_statements:
+            # 2. CANONICALISE TOKEN NAMES — rename cache attributes to the
+            #    semconv 1.41 canonical dotted form. Runs at span level (not
+            #    in the copy step) because product-reviews sets a
+            #    non-canonical cache_write.input_tokens directly on the span
+            #    and never passes through copy; handling it here in one place
+            #    covers that and Strands' promoted underscore names alike.
             - context: span
               conditions:
                   - attributes["gen_ai.usage.input_tokens"] != nil
@@ -277,18 +277,18 @@ config:
                   - set(attributes["gen_ai.usage.cache_creation.input_tokens"], attributes["gen_ai.usage.cache_write_input_tokens"]) where attributes["gen_ai.usage.cache_write_input_tokens"] != nil and attributes["gen_ai.usage.cache_creation.input_tokens"] == nil
                   - set(attributes["gen_ai.usage.cache_creation.input_tokens"], attributes["gen_ai.usage.cache_write.input_tokens"]) where attributes["gen_ai.usage.cache_write.input_tokens"] != nil and attributes["gen_ai.usage.cache_creation.input_tokens"] == nil
 
-    # 3. FIX TOKEN COUNTS — runs on span attributes only, after names are
-    #    canonical. Covers Strands (events) and product-reviews (native span
-    #    attrs) alike in one span-context pass.
-    #
-    #    ASSUMPTION: our SDKs report gen_ai.usage.input_tokens as the UNCACHED
-    #    portion only (raw Bedrock inputTokens), with cache read/creation counted
-    #    separately. Verified for Strands + product-reviews. If an SDK is ever
-    #    upgraded to emit semconv-compliant input_tokens (already inclusive of
-    #    cached tokens), revisit — the additive step below would double-count.
-    transform/genai_fix_token_counts:
-        error_mode: ignore
-        trace_statements:
+            # 3. FIX TOKEN COUNTS — runs on span attributes only, after
+            #    names are canonical. Covers Strands (events) and
+            #    product-reviews (native span attrs) alike in one
+            #    span-context pass.
+            #
+            #    ASSUMPTION: our SDKs report gen_ai.usage.input_tokens as
+            #    the UNCACHED portion only (raw Bedrock inputTokens), with
+            #    cache read/creation counted separately. Verified for
+            #    Strands + product-reviews. If an SDK is ever upgraded to
+            #    emit semconv-compliant input_tokens (already inclusive of
+            #    cached tokens), revisit — the additive step below would
+            #    double-count.
             - context: span
               conditions:
                   - attributes["gen_ai.usage.input_tokens"] != nil
@@ -305,6 +305,97 @@ config:
                   # belongs here, not with the free cache reads.
                   - set(attributes["demo.gen_ai.usage.uncached_input_tokens"], attributes["gen_ai.usage.input_tokens"] - attributes["gen_ai.usage.cache_read.input_tokens"]) where attributes["gen_ai.usage.cache_read.input_tokens"] != nil
                   - set(attributes["demo.gen_ai.usage.uncached_input_tokens"], attributes["gen_ai.usage.input_tokens"]) where attributes["gen_ai.usage.cache_read.input_tokens"] == nil
+
+            # 4. STRANDS SEMCONV SHAPING — runs after 1-3 so token
+            #    names/counts are already canonical. Strands 1.45.x stamps
+            #    framework metadata on every span it creates; the latest
+            #    GenAI semconv (open-telemetry/semantic-conventions-genai)
+            #    allows each attribute only on specific span types. Reshape
+            #    so each attribute appears only where its spec table
+            #    includes it, and provider.name is the *model provider* on
+            #    inference spans (aws.bedrock — a well-known value MUST be
+            #    used when it applies) and absent on in-process invoke_agent
+            #    / execute_tool spans, whose spec tables have no provider
+            #    attribute. Conditioned on the hardcoded
+            #    provider.name=strands-agents marker so it self-scopes to
+            #    Strands telemetry regardless of emitting service.
+            - context: span
+              conditions:
+                  - attributes["gen_ai.provider.name"] == "strands-agents" and attributes["gen_ai.operation.name"] == "chat"
+              statements:
+                  # Client-observed model timing is not a semconv span
+                  # attribute (gen_ai.server.* exist only as metrics); keep
+                  # the data under the demo.* namespace.
+                  - set(attributes["demo.gen_ai.server.time_to_first_token"], attributes["gen_ai.server.time_to_first_token"]) where attributes["gen_ai.server.time_to_first_token"] != nil
+                  - set(attributes["demo.gen_ai.server.request.duration"], attributes["gen_ai.server.request.duration"]) where attributes["gen_ai.server.request.duration"] != nil
+                  # Attributes not in the semconv inference-span table.
+                  - delete_key(attributes, "gen_ai.server.time_to_first_token")
+                  - delete_key(attributes, "gen_ai.server.request.duration")
+                  - delete_key(attributes, "gen_ai.usage.prompt_tokens")
+                  - delete_key(attributes, "gen_ai.usage.completion_tokens")
+                  - delete_key(attributes, "gen_ai.usage.total_tokens")
+                  - delete_key(attributes, "gen_ai.usage.cache_read_input_tokens")
+                  - delete_key(attributes, "gen_ai.usage.cache_write_input_tokens")
+                  - delete_key(attributes, "gen_ai.agent.name")
+                  - delete_key(attributes, "gen_ai.agent.description")
+                  - delete_key(attributes, "gen_ai.event.start_time")
+                  - delete_key(attributes, "gen_ai.event.end_time")
+                  # Inference spans: name SHOULD be `{operation}
+                  # {request.model}`, kind SHOULD be CLIENT (remote model
+                  # over HTTP), provider MUST be aws.bedrock.
+                  - set(name, Concat(["chat ", attributes["gen_ai.request.model"]], "")) where attributes["gen_ai.request.model"] != nil
+                  - set(kind, SPAN_KIND_CLIENT)
+                  - set(attributes["gen_ai.provider.name"], "aws.bedrock")
+            - context: span
+              conditions:
+                  - attributes["gen_ai.provider.name"] == "strands-agents" and attributes["gen_ai.operation.name"] == "invoke_agent"
+              statements:
+                  - delete_key(attributes, "gen_ai.usage.prompt_tokens")
+                  - delete_key(attributes, "gen_ai.usage.completion_tokens")
+                  - delete_key(attributes, "gen_ai.usage.total_tokens")
+                  - delete_key(attributes, "gen_ai.usage.cache_read_input_tokens")
+                  - delete_key(attributes, "gen_ai.usage.cache_write_input_tokens")
+                  - delete_key(attributes, "gen_ai.agent.tools")
+                  - delete_key(attributes, "system_prompt")
+                  - delete_key(attributes, "gen_ai.event.start_time")
+                  - delete_key(attributes, "gen_ai.event.end_time")
+                  # invoke_agent usage aggregates the child chat spans;
+                  # fix_token_counts computes demo.* uncached here too, and
+                  # keeping it would double-count in SUMs and skew the SLI.
+                  - delete_key(attributes, "demo.gen_ai.usage.uncached_input_tokens")
+                  # The in-process invoke_agent span table has no
+                  # provider.name.
+                  - delete_key(attributes, "gen_ai.provider.name")
+            - context: span
+              conditions:
+                  - attributes["gen_ai.provider.name"] == "strands-agents" and attributes["gen_ai.operation.name"] == "execute_tool"
+              statements:
+                  # execute_tool records content as gen_ai.tool.call.arguments
+                  # / gen_ai.tool.call.result (set by the app), not
+                  # input/output messages.
+                  - delete_key(attributes, "gen_ai.input.messages")
+                  - delete_key(attributes, "gen_ai.output.messages")
+                  - delete_key(attributes, "gen_ai.tool.status")
+                  - delete_key(attributes, "gen_ai.tool.json_schema")
+                  - delete_key(attributes, "gen_ai.agent.description")
+                  - delete_key(attributes, "gen_ai.request.max_tokens")
+                  - delete_key(attributes, "gen_ai.event.start_time")
+                  - delete_key(attributes, "gen_ai.event.end_time")
+                  - delete_key(attributes, "gen_ai.provider.name")
+            - context: span
+              conditions:
+                  - attributes["gen_ai.provider.name"] == "strands-agents" and attributes["gen_ai.operation.name"] == "execute_event_loop_cycle"
+              statements:
+                  # Framework-internal span (custom operation, allowed);
+                  # carries no model call of its own, so no content or
+                  # request params.
+                  - delete_key(attributes, "gen_ai.input.messages")
+                  - delete_key(attributes, "gen_ai.output.messages")
+                  - delete_key(attributes, "gen_ai.agent.description")
+                  - delete_key(attributes, "gen_ai.request.max_tokens")
+                  - delete_key(attributes, "gen_ai.event.start_time")
+                  - delete_key(attributes, "gen_ai.event.end_time")
+                  - delete_key(attributes, "gen_ai.provider.name")
 
     # Promote `exception.type` from the OTel `exception` span event onto
     # the span itself as `error.type`, per the gen_ai/general-error
@@ -465,23 +556,21 @@ config:
           - otlp/bindplane
         processors:
           - filter/drop_flagd_spans
-          - transform/genai_copy_events_to_span
-          - transform/genai_canonicalize_token_names
-          - transform/genai_fix_token_counts
+          - transform/genai_semconv
           - transform/exception_type_to_error_type
           - transform/service_names
           - transform/attribution
 
       # Eval anchor pipeline. Pushes one span per chatbot turn to Kafka;
       # the llm-evals service consumes and runs Bias/Hallucination/Relevance.
-      # genai_copy_events_to_span runs first to promote Strands-style event
-      # attributes onto the span — without that, invoke_agent spans arrive at
-      # the consumer with gen_ai.input.messages still on the span event and the
-      # consumer skips them. fix_token_counts keeps the eval anchor's token
-      # counts consistent with the main traces pipeline.
+      # genai_semconv promotes Strands-style event attributes onto the span
+      # and normalises token names/counts first — without that, invoke_agent
+      # spans arrive at the consumer with gen_ai.input.messages still on the
+      # span event and the consumer skips them, and token counts would
+      # diverge from the main traces pipeline.
       traces/evals:
         receivers: [otlp]
-        processors: [transform/genai_copy_events_to_span, transform/genai_canonicalize_token_names, transform/genai_fix_token_counts, filter/keep_eval_anchors]
+        processors: [transform/genai_semconv, filter/keep_eval_anchors]
         exporters: [kafka/llm-evals]
 
       # Isolated pipeline that publishes a Honeycomb marker per

--- a/skaffold-config/charts/otel-services/values.yaml
+++ b/skaffold-config/charts/otel-services/values.yaml
@@ -105,8 +105,12 @@ services:
         value: "8013"
       - name: FLAGD_OFREP_PORT
         value: "8016"
+      # gen_ai_latest_experimental: latest GenAI semconv shape.
+      # gen_ai_tool_definitions: gen_ai.tool.definitions on invoke_agent spans.
+      # gen_ai_use_latest_invocation_tokens: invoke_agent usage tokens scoped
+      #   to the current invocation, not the agent's accumulated totals.
       - name: OTEL_SEMCONV_STABILITY_OPT_IN
-        value: "gen_ai_latest_experimental"
+        value: "gen_ai_latest_experimental,gen_ai_tool_definitions,gen_ai_use_latest_invocation_tokens"
       - name: OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT
         value: "true"
 

--- a/skaffold-config/demo-values.yaml
+++ b/skaffold-config/demo-values.yaml
@@ -170,22 +170,24 @@ opentelemetry-collector:
               - set(attributes["meta.annotation_type"], "span_event")
       # ── GenAI span shaping ──────────────────────────────────────────
       # Strands (storechat) and product-reviews emit GenAI telemetry that
-      # needs shaping before it's useful in Honeycomb. Split into three
-      # small processors so each job is self-contained:
-      #   1. genai_copy_events_to_span      — promote Strands' span-EVENT
-      #      attributes onto the parent span. Pure copy, no math.
-      #   2. genai_canonicalize_token_names — rename cache attributes to the
-      #      semconv 1.41 canonical dotted form (covers both sources).
-      #   3. genai_fix_token_counts         — reconstruct semconv-correct
-      #      token counts (input_tokens must include cached tokens).
-
-      # 1. COPY TO SPAN — Strands emits messages + usage on a
-      #    `gen_ai.client.inference.operation.details` span event; copy each
-      #    attribute up to the span verbatim. product-reviews already sets
-      #    these on the span, so it skips this step (handled by 2 + 3).
-      transform/genai_copy_events_to_span:
+      # needs shaping before it's useful in Honeycomb. One processor,
+      # staged statement groups that run in order:
+      #   1. COPY TO SPAN          — promote Strands' span-EVENT attributes
+      #      onto the parent span. Pure copy, no math.
+      #   2. CANONICALISE NAMES    — rename cache attributes to the semconv
+      #      1.41 canonical dotted form (covers both sources).
+      #   3. FIX TOKEN COUNTS      — reconstruct semconv-correct token
+      #      counts (input_tokens must include cached tokens).
+      #   4. STRANDS SEMCONV SHAPE — per-operation attribute placement for
+      #      Strands spans per the latest GenAI semconv tables.
+      transform/genai_semconv:
         error_mode: ignore
         trace_statements:
+          # 1. COPY TO SPAN — Strands emits messages + usage on a
+          #    `gen_ai.client.inference.operation.details` span event; copy
+          #    each attribute up to the span verbatim. product-reviews
+          #    already sets these on the span, so it skips this step
+          #    (handled by 2 + 3).
           - context: spanevent
             conditions:
               - IsMatch(name, "^gen_ai\\..*")
@@ -204,14 +206,12 @@ opentelemetry-collector:
               - set(span.attributes["gen_ai.request.model"], attributes["gen_ai.request.model"]) where attributes["gen_ai.request.model"] != nil
               - set(span.attributes["gen_ai.operation.name"], attributes["gen_ai.operation.name"]) where attributes["gen_ai.operation.name"] != nil
 
-      # 2. CANONICALISE TOKEN NAMES — rename cache attributes to the semconv
-      #    1.41 canonical dotted form. Runs at span level (not in copy)
-      #    because product-reviews sets a non-canonical
-      #    cache_write.input_tokens directly on the span and never passes
-      #    through copy; handling it here covers both sources alike.
-      transform/genai_canonicalize_token_names:
-        error_mode: ignore
-        trace_statements:
+          # 2. CANONICALISE TOKEN NAMES — rename cache attributes to the
+          #    semconv 1.41 canonical dotted form. Runs at span level (not
+          #    in copy) because product-reviews sets a non-canonical
+          #    cache_write.input_tokens directly on the span and never
+          #    passes through copy; handling it here covers both sources
+          #    alike.
           - context: span
             conditions:
               - attributes["gen_ai.usage.input_tokens"] != nil
@@ -224,19 +224,17 @@ opentelemetry-collector:
               - set(attributes["gen_ai.usage.cache_creation.input_tokens"], attributes["gen_ai.usage.cache_write_input_tokens"]) where attributes["gen_ai.usage.cache_write_input_tokens"] != nil and attributes["gen_ai.usage.cache_creation.input_tokens"] == nil
               - set(attributes["gen_ai.usage.cache_creation.input_tokens"], attributes["gen_ai.usage.cache_write.input_tokens"]) where attributes["gen_ai.usage.cache_write.input_tokens"] != nil and attributes["gen_ai.usage.cache_creation.input_tokens"] == nil
 
-      # 3. FIX TOKEN COUNTS — runs on span attributes only, after names are
-      #    canonical. Covers Strands (events) and product-reviews (native
-      #    span attrs) alike in one span-context pass.
-      #
-      #    ASSUMPTION: our SDKs report gen_ai.usage.input_tokens as the
-      #    UNCACHED portion only (raw Bedrock inputTokens), with cache
-      #    read/creation counted separately. Verified for Strands +
-      #    product-reviews. If an SDK is upgraded to emit semconv-compliant
-      #    input_tokens (already inclusive of cached tokens), revisit — the
-      #    additive step below would double-count.
-      transform/genai_fix_token_counts:
-        error_mode: ignore
-        trace_statements:
+          # 3. FIX TOKEN COUNTS — runs on span attributes only, after names
+          #    are canonical. Covers Strands (events) and product-reviews
+          #    (native span attrs) alike in one span-context pass.
+          #
+          #    ASSUMPTION: our SDKs report gen_ai.usage.input_tokens as the
+          #    UNCACHED portion only (raw Bedrock inputTokens), with cache
+          #    read/creation counted separately. Verified for Strands +
+          #    product-reviews. If an SDK is upgraded to emit
+          #    semconv-compliant input_tokens (already inclusive of cached
+          #    tokens), revisit — the additive step below would
+          #    double-count.
           - context: span
             conditions:
               - attributes["gen_ai.usage.input_tokens"] != nil
@@ -252,6 +250,110 @@ opentelemetry-collector:
               # the full input minus what was read from cache.
               - set(attributes["demo.gen_ai.usage.uncached_input_tokens"], attributes["gen_ai.usage.input_tokens"] - attributes["gen_ai.usage.cache_read.input_tokens"]) where attributes["gen_ai.usage.cache_read.input_tokens"] != nil
               - set(attributes["demo.gen_ai.usage.uncached_input_tokens"], attributes["gen_ai.usage.input_tokens"]) where attributes["gen_ai.usage.cache_read.input_tokens"] == nil
+
+          # 4. STRANDS SEMCONV SHAPING — runs after 1-3 so token
+          #    names/counts are already canonical. Strands 1.45.x stamps
+          #    framework metadata on every span it creates; the latest GenAI
+          #    semconv (open-telemetry/semantic-conventions-genai) allows
+          #    each attribute only on specific span types. Reshape so each
+          #    attribute appears only where its spec table includes it, and
+          #    provider.name is the *model provider* on inference spans
+          #    (aws.bedrock — a well-known value MUST be used when it
+          #    applies) and absent on in-process invoke_agent / execute_tool
+          #    spans, whose spec tables have no provider attribute.
+          #    Conditioned on the hardcoded provider.name=strands-agents
+          #    marker so it self-scopes to Strands telemetry regardless of
+          #    which service emits it.
+          - context: span
+            conditions:
+              - attributes["gen_ai.provider.name"] == "strands-agents" and attributes["gen_ai.operation.name"] == "chat"
+            statements:
+              # Client-observed model timing is not a semconv span attribute
+              # (gen_ai.server.* exist only as metrics); keep the data under
+              # the demo.* namespace.
+              - set(attributes["demo.gen_ai.server.time_to_first_token"], attributes["gen_ai.server.time_to_first_token"]) where attributes["gen_ai.server.time_to_first_token"] != nil
+              - set(attributes["demo.gen_ai.server.request.duration"], attributes["gen_ai.server.request.duration"]) where attributes["gen_ai.server.request.duration"] != nil
+              # Attributes not in the semconv inference-span table.
+              - delete_key(attributes, "gen_ai.server.time_to_first_token")
+              - delete_key(attributes, "gen_ai.server.request.duration")
+              - delete_key(attributes, "gen_ai.usage.prompt_tokens")
+              - delete_key(attributes, "gen_ai.usage.completion_tokens")
+              - delete_key(attributes, "gen_ai.usage.total_tokens")
+              - delete_key(attributes, "gen_ai.usage.cache_read_input_tokens")
+              - delete_key(attributes, "gen_ai.usage.cache_write_input_tokens")
+              - delete_key(attributes, "gen_ai.agent.name")
+              - delete_key(attributes, "gen_ai.agent.description")
+              - delete_key(attributes, "gen_ai.event.start_time")
+              - delete_key(attributes, "gen_ai.event.end_time")
+              # Inference spans: name SHOULD be `{operation} {request.model}`,
+              # kind SHOULD be CLIENT (remote model over HTTP), provider MUST
+              # be aws.bedrock.
+              - set(name, Concat(["chat ", attributes["gen_ai.request.model"]], "")) where attributes["gen_ai.request.model"] != nil
+              - set(kind, SPAN_KIND_CLIENT)
+              - set(attributes["gen_ai.provider.name"], "aws.bedrock")
+          - context: span
+            conditions:
+              - attributes["gen_ai.provider.name"] == "strands-agents" and attributes["gen_ai.operation.name"] == "invoke_agent"
+            statements:
+              - delete_key(attributes, "gen_ai.usage.prompt_tokens")
+              - delete_key(attributes, "gen_ai.usage.completion_tokens")
+              - delete_key(attributes, "gen_ai.usage.total_tokens")
+              - delete_key(attributes, "gen_ai.usage.cache_read_input_tokens")
+              - delete_key(attributes, "gen_ai.usage.cache_write_input_tokens")
+              - delete_key(attributes, "gen_ai.agent.tools")
+              - delete_key(attributes, "system_prompt")
+              - delete_key(attributes, "gen_ai.event.start_time")
+              - delete_key(attributes, "gen_ai.event.end_time")
+              # invoke_agent usage aggregates the child chat spans;
+              # fix_token_counts computes demo.* uncached here too, and
+              # keeping it would double-count in SUMs and skew the SLI.
+              - delete_key(attributes, "demo.gen_ai.usage.uncached_input_tokens")
+              # The in-process invoke_agent span table has no provider.name.
+              - delete_key(attributes, "gen_ai.provider.name")
+          - context: span
+            conditions:
+              - attributes["gen_ai.provider.name"] == "strands-agents" and attributes["gen_ai.operation.name"] == "execute_tool"
+            statements:
+              # execute_tool records content as gen_ai.tool.call.arguments /
+              # gen_ai.tool.call.result (set by the app), not input/output
+              # messages.
+              - delete_key(attributes, "gen_ai.input.messages")
+              - delete_key(attributes, "gen_ai.output.messages")
+              - delete_key(attributes, "gen_ai.tool.status")
+              - delete_key(attributes, "gen_ai.tool.json_schema")
+              - delete_key(attributes, "gen_ai.agent.description")
+              - delete_key(attributes, "gen_ai.request.max_tokens")
+              - delete_key(attributes, "gen_ai.event.start_time")
+              - delete_key(attributes, "gen_ai.event.end_time")
+              - delete_key(attributes, "gen_ai.provider.name")
+          - context: span
+            conditions:
+              - attributes["gen_ai.provider.name"] == "strands-agents" and attributes["gen_ai.operation.name"] == "execute_event_loop_cycle"
+            statements:
+              # Framework-internal span (custom operation, allowed); carries
+              # no model call of its own, so no content or request params.
+              - delete_key(attributes, "gen_ai.input.messages")
+              - delete_key(attributes, "gen_ai.output.messages")
+              - delete_key(attributes, "gen_ai.agent.description")
+              - delete_key(attributes, "gen_ai.request.max_tokens")
+              - delete_key(attributes, "gen_ai.event.start_time")
+              - delete_key(attributes, "gen_ai.event.end_time")
+              - delete_key(attributes, "gen_ai.provider.name")
+
+      # Promote `exception.type` from the OTel `exception` span event onto
+      # the span itself as `error.type`, per the gen_ai/general-error
+      # semconv (Conditionally Required when the operation errored). SDKs
+      # like Strands call record_exception() (which writes the event) but
+      # don't set span-level error.type. Kept to the last `.`-segment so
+      # error.type stays low-cardinality.
+      transform/exception_type_to_error_type:
+        error_mode: ignore
+        trace_statements:
+          - context: spanevent
+            conditions:
+              - name == "exception"
+            statements:
+              - set(span.attributes["error.type"], ExtractPatterns(attributes["exception.type"], "(?P<class>[^.]+)$")["class"]) where attributes["exception.type"] != nil and span.attributes["error.type"] == nil
       transform/service_names:
         error_mode: ignore
         log_statements:
@@ -419,9 +521,8 @@ opentelemetry-collector:
             - spanmetrics
           processors:
             - filter/drop_flagd_spans
-            - transform/genai_copy_events_to_span
-            - transform/genai_canonicalize_token_names
-            - transform/genai_fix_token_counts
+            - transform/genai_semconv
+            - transform/exception_type_to_error_type
             - transform/service_names
             - transform/attribution
 
@@ -430,18 +531,17 @@ opentelemetry-collector:
         # JSON, extracts gen_ai.input.messages / gen_ai.output.messages,
         # and runs scorers — no producer-side publish_eval calls needed.
         #
-        # genai_copy_events_to_span promotes Strands-style event attributes
-        # onto the span first; without it, invoke_agent spans arrive at the
-        # consumer with gen_ai.input.messages still on span events and the
-        # consumer skips them. canonicalize + fix_token_counts keep the eval
-        # anchor's token counts consistent with the main traces pipeline.
+        # genai_semconv promotes Strands-style event attributes onto the
+        # span and normalises token names/counts first; without it,
+        # invoke_agent spans arrive at the consumer with
+        # gen_ai.input.messages still on span events and the consumer skips
+        # them, and token counts would diverge from the main traces
+        # pipeline.
         traces/evals:
           receivers:
             - otlp
           processors:
-            - transform/genai_copy_events_to_span
-            - transform/genai_canonicalize_token_names
-            - transform/genai_fix_token_counts
+            - transform/genai_semconv
             - filter/keep_eval_anchors
           exporters:
             - kafka/llm-evals

--- a/src/storechat/Dockerfile
+++ b/src/storechat/Dockerfile
@@ -20,6 +20,11 @@ COPY src/storechat/ .
 
 EXPOSE 8080
 
-ENV OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+# gen_ai_latest_experimental: emit the latest GenAI semconv shape.
+# gen_ai_tool_definitions: include gen_ai.tool.definitions on invoke_agent
+#   spans (Opt-In attribute in the spec's internal invoke_agent table).
+# gen_ai_use_latest_invocation_tokens: scope invoke_agent usage tokens to the
+#   current invocation rather than the agent object's accumulated totals.
+ENV OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental,gen_ai_tool_definitions,gen_ai_use_latest_invocation_tokens
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/src/storechat/agents.py
+++ b/src/storechat/agents.py
@@ -3,6 +3,7 @@ import os
 from strands import Agent, tool
 from strands.models.bedrock import BedrockModel
 
+from telemetry import record_tool_call
 from tools import check_shipping, get_order, lookup_orders, refund_order
 
 # Bedrock inference profile ARNs per agent role. Supervisor stays on Haiku 4.5
@@ -408,6 +409,11 @@ wrong.
 """
 
 
+# Shared between the Bedrock request config and gen_ai.request.max_tokens
+# trace attributes so the reported value can't drift from the actual request.
+MAX_TOKENS = 1024
+
+
 def _make_model(model_id: str, *, enable_caching: bool) -> BedrockModel | None:
     if not model_id:
         return None
@@ -421,7 +427,7 @@ def _make_model(model_id: str, *, enable_caching: bool) -> BedrockModel | None:
     # message-tail breakpoint). With ~1.5 LLM calls per chat span, the auto
     # breakpoint writes deltas that are rarely re-read, and the write tax
     # exceeds the read savings.
-    kwargs: dict = {"model_id": model_id, "max_tokens": 1024}
+    kwargs: dict = {"model_id": model_id, "max_tokens": MAX_TOKENS}
     if enable_caching:
         kwargs["cache_prompt"] = "default"
         kwargs["cache_tools"] = "default"
@@ -430,10 +436,30 @@ def _make_model(model_id: str, *, enable_caching: bool) -> BedrockModel | None:
 
 # --- Agent factory functions ---
 # Created per-request so trace_attributes (conversation ID) can be set.
+#
+# Strands stamps trace_attributes on *every* span the agent creates
+# (invoke_agent, chat, execute_tool, event-loop cycles), but the GenAI
+# semconv allows each attribute only on specific span types (e.g.
+# gen_ai.agent.name belongs on invoke_agent and execute_tool spans, not on
+# chat inference spans). The collector's genai transform deletes the
+# attributes from the span types whose spec tables don't include them.
+
+
+def _agent_trace_attributes(trace_attributes: dict, *, name: str, description: str) -> dict:
+    return {
+        **trace_attributes,
+        "gen_ai.agent.name": name,
+        "gen_ai.agent.description": description,
+        "gen_ai.request.max_tokens": MAX_TOKENS,
+    }
 
 
 def _make_order_status_agent(trace_attributes: dict) -> Agent:
-    attrs = {**trace_attributes, "gen_ai.agent.name": "order_status_agent"}
+    attrs = _agent_trace_attributes(
+        trace_attributes,
+        name="order_status_agent",
+        description="Looks up a customer's orders, order details, and shipping status.",
+    )
     kwargs: dict = {
         "name": "order_status_agent",
         "system_prompt": (
@@ -454,7 +480,11 @@ def _make_order_status_agent(trace_attributes: dict) -> Agent:
 
 
 def _make_refund_agent(trace_attributes: dict) -> Agent:
-    attrs = {**trace_attributes, "gen_ai.agent.name": "refund_agent"}
+    attrs = _agent_trace_attributes(
+        trace_attributes,
+        name="refund_agent",
+        description="Confirms and processes order refunds for customers.",
+    )
     kwargs: dict = {
         "name": "refund_agent",
         "system_prompt": (
@@ -514,6 +544,7 @@ def create_supervisor(
     refund_agent = _make_refund_agent(trace_attrs)
 
     @tool
+    @record_tool_call
     def check_order_status(question: str, email: str) -> str:
         """Look up a customer's orders and check shipping status.
 
@@ -530,6 +561,7 @@ def create_supervisor(
         return str(result)
 
     @tool
+    @record_tool_call
     def process_refund(question: str, email: str) -> str:
         """Process a refund for a customer's order.
 
@@ -545,7 +577,11 @@ def create_supervisor(
         result = refund_agent(f"Customer email: {email}\nRequest: {question}")
         return str(result)
 
-    supervisor_attrs = {**trace_attrs, "gen_ai.agent.name": "supervisor"}
+    supervisor_attrs = _agent_trace_attributes(
+        trace_attrs,
+        name="supervisor",
+        description="Front-line customer support assistant that routes order-status and refund requests to sub-agents.",
+    )
     kwargs: dict = {
         "name": "supervisor",
         "system_prompt": SUPERVISOR_SYSTEM_PROMPT,

--- a/src/storechat/main.py
+++ b/src/storechat/main.py
@@ -15,6 +15,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from pydantic import BaseModel
 
 import conversation
+import telemetry
 from agents import create_supervisor
 
 logging.basicConfig(level=logging.INFO)
@@ -27,6 +28,10 @@ resource = Resource.create({
 provider = TracerProvider(resource=resource)
 provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
 trace.set_tracer_provider(provider)
+
+# Reshape Strands GenAI telemetry to the latest semconv (content as span
+# attributes instead of span events). Must run before any agent executes.
+telemetry.patch_strands_tracer()
 
 app = FastAPI(title="Store Chat")
 

--- a/src/storechat/requirements.txt
+++ b/src/storechat/requirements.txt
@@ -1,5 +1,5 @@
-strands-agents[otel]
-strands-agents-tools
+strands-agents[otel]==1.45.0
+strands-agents-tools==0.8.2
 fastapi
 uvicorn[standard]
 httpx

--- a/src/storechat/telemetry.py
+++ b/src/storechat/telemetry.py
@@ -1,0 +1,125 @@
+"""Shapes Strands telemetry to the latest OTel GenAI semantic conventions.
+
+Two adjustments the Strands SDK (1.45.0) does not offer natively:
+
+1. Content on span attributes, not span events. The GenAI semconv
+   (open-telemetry/semantic-conventions-genai, "Capturing instructions,
+   inputs, and outputs") defines opt-in content capture as the span
+   attributes gen_ai.system_instructions / gen_ai.input.messages /
+   gen_ai.output.messages. Strands instead emits
+   `gen_ai.client.inference.operation.details` span events, which both
+   duplicates the payload and puts it where the spec doesn't look.
+   `patch_strands_tracer` rewrites the tracer's event hook to set the
+   attributes directly and emit no events. Content attributes are only
+   applied to the span types whose spec tables include them (`chat`
+   inference spans and internal `invoke_agent` spans) — tool spans get the
+   dedicated gen_ai.tool.call.* attributes from `record_tool_call` instead.
+
+2. gen_ai.response.finish_reasons (Recommended on inference spans) only
+   exists inside Strands' serialized output-message JSON; the patch lifts
+   it out onto the chat span.
+
+The collector's transform/genai_span_events_to_attributes processor
+finishes the reshaping for things only known span-wide (provider name,
+canonical token attribute names, span name/kind).
+"""
+
+import functools
+import inspect
+import json
+import logging
+
+from opentelemetry import trace
+from strands.telemetry.tracer import Tracer
+
+logger = logging.getLogger(__name__)
+
+# Span-attribute content capture is only defined for inference and
+# in-process agent spans in the semconv tables.
+_CONTENT_OPS = {"chat", "invoke_agent"}
+_CONTENT_ATTRS = {
+    "gen_ai.system_instructions",
+    "gen_ai.input.messages",
+    "gen_ai.output.messages",
+}
+
+
+def _span_operation(span) -> str | None:
+    attributes = getattr(span, "attributes", None)
+    if not attributes:
+        return None
+    return attributes.get("gen_ai.operation.name")
+
+
+def _finish_reasons(output_messages_json: str) -> list[str]:
+    messages = json.loads(output_messages_json)
+    return [m["finish_reason"] for m in messages if isinstance(m, dict) and "finish_reason" in m]
+
+
+def _add_event_as_attributes(self, span, event_name, event_attributes, to_span_attributes=False):
+    """Replacement for Tracer._add_event: content goes to span attributes."""
+    if span is None or not event_attributes:
+        return
+
+    operation = _span_operation(span)
+    if operation not in _CONTENT_OPS:
+        return
+
+    attrs = {k: v for k, v in event_attributes.items() if k in _CONTENT_ATTRS}
+    if not attrs:
+        return
+
+    output_messages = attrs.get("gen_ai.output.messages")
+    if operation == "chat" and isinstance(output_messages, str):
+        try:
+            reasons = _finish_reasons(output_messages)
+            if reasons:
+                attrs["gen_ai.response.finish_reasons"] = reasons
+        except (ValueError, TypeError, KeyError):
+            logger.debug("could not extract finish_reasons from output messages")
+
+    span.set_attributes(attrs)
+
+
+def patch_strands_tracer() -> None:
+    """Apply the event-to-attribute patch. Call once at startup, before any agent runs."""
+    Tracer._add_event = _add_event_as_attributes
+
+
+def record_tool_call(fn):
+    """Record semconv execute_tool attributes on the current Strands tool span.
+
+    Strands creates the `execute_tool {name}` span and runs the tool inside
+    it, but only sets gen_ai.tool.name and gen_ai.tool.call.id. This adds the
+    Recommended gen_ai.tool.type / gen_ai.tool.description and the Opt-In
+    gen_ai.tool.call.arguments / gen_ai.tool.call.result. Place it *under*
+    @tool so it wraps the raw function.
+    """
+    description = inspect.cleandoc(fn.__doc__ or "").split("\n\n")[0].replace("\n", " ").strip()
+    signature = inspect.signature(fn)
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        span = trace.get_current_span()
+        on_tool_span = span.is_recording() and _span_operation(span) == "execute_tool"
+        if on_tool_span:
+            attrs = {"gen_ai.tool.type": "function"}
+            if description:
+                attrs["gen_ai.tool.description"] = description
+            try:
+                bound = signature.bind(*args, **kwargs)
+                attrs["gen_ai.tool.call.arguments"] = json.dumps(dict(bound.arguments))
+            except (TypeError, ValueError):
+                pass
+            span.set_attributes(attrs)
+
+        result = fn(*args, **kwargs)
+
+        if on_tool_span:
+            span.set_attribute(
+                "gen_ai.tool.call.result",
+                result if isinstance(result, str) else json.dumps(result),
+            )
+        return result
+
+    return wrapper

--- a/src/storechat/tools.py
+++ b/src/storechat/tools.py
@@ -6,6 +6,7 @@ import httpx
 from strands import tool
 
 from genproto import demo_pb2, demo_pb2_grpc
+from telemetry import record_tool_call
 
 ACCOUNTING_ADDR = os.environ.get("ACCOUNTING_ADDR", "accounting:5060")
 SHIPPING_ADDR = os.environ.get("SHIPPING_ADDR", "http://shipping:8080")
@@ -52,6 +53,7 @@ def _order_detail_to_dict(d) -> dict:
 
 
 @tool
+@record_tool_call
 def lookup_orders(email: str) -> str:
     """Find all orders for a customer by their email address.
 
@@ -69,6 +71,7 @@ def lookup_orders(email: str) -> str:
 
 
 @tool
+@record_tool_call
 def get_order(order_id: str) -> str:
     """Get full details for a specific order including items, shipping, and payment status.
 
@@ -85,6 +88,7 @@ def get_order(order_id: str) -> str:
 
 
 @tool
+@record_tool_call
 def check_shipping(tracking_id: str) -> str:
     """Check the shipping status for a tracking ID.
 
@@ -100,6 +104,7 @@ def check_shipping(tracking_id: str) -> str:
 
 
 @tool
+@record_tool_call
 def refund_order(order_id: str, email: str) -> str:
     """Process a refund for an order. Requires the customer's email for verification.
 


### PR DESCRIPTION
## What

Makes store-chat's telemetry an exemplar of the **latest GenAI semantic conventions** ([open-telemetry/semantic-conventions-genai](https://github.com/open-telemetry/semantic-conventions-genai), the new dedicated repo): no `gen_ai.*` attribute appears on a span type whose spec table doesn't include it, all Recommended attributes we can populate are present, and every value follows spec semantics.

### The headline fix

Strands hardcodes `gen_ai.provider.name="strands-agents"` on every span it creates. Per the spec:

- **`chat` inference spans**: provider MUST be `aws.bedrock` (well-known value list), name SHOULD be `chat {request.model}`, kind SHOULD be CLIENT.
- **In-process `invoke_agent` / `execute_tool` spans**: their spec tables have **no provider attribute at all** — it's deleted.

### Resulting span shapes (validated)

| Span | Kind | Now carries | No longer carries |
|---|---|---|---|
| `chat {model ARN}` | client | `provider.name=aws.bedrock`, request.model, request.max_tokens, conversation.id, usage input/output + `cache_read.input_tokens`/`cache_creation.input_tokens` (canonical dotted names), **response.finish_reasons**, input/output.messages, system_instructions | agent.name, event times, prompt/completion/total_tokens, underscore cache names, server timing (moved to `demo.gen_ai.server.*`) |
| `invoke_agent {name}` | internal | agent.name, **agent.description**, conversation.id, request.model, request.max_tokens, usage tokens, **tool.definitions**, input/output.messages | provider.name, agent.tools, bare system_prompt, demo.* uncached (double-counted child chat spans) |
| `execute_tool {name}` | internal | tool.name, tool.call.id, agent.name, **tool.type, tool.description, tool.call.arguments, tool.call.result**, conversation.id | provider.name, tool.status, input/output.messages |
| `execute_event_loop_cycle` | internal | agent.name, conversation.id (framework-custom op, allowed) | provider.name, messages, event times |

### How

- **`src/storechat/telemetry.py` (new)** — patches Strands' `Tracer._add_event` so content lands on **span attributes** (the spec's "recording content on attributes" pattern) instead of duplicate `gen_ai.client.inference.operation.details` span events (span events on Strands spans are now zero — this also cuts ingest volume); lifts `finish_reasons` out of the serialized output messages. Plus a `record_tool_call` decorator on all six tools.
- **`agents.py`** — per-agent trace attributes carry agent.name/description and request.max_tokens (shared `MAX_TOKENS` constant); the collector strips each from span types that don't allow it.
- **Pins** `strands-agents[otel]==1.45.0` and `strands-agents-tools==0.8.2` explicitly.
- **Opt-ins** extended to `gen_ai_tool_definitions` + `gen_ai_use_latest_invocation_tokens` (Dockerfile *and* otel-services chart env — the chart env overrides the image ENV).
- **Collector** (`skaffold-config/demo-values.yaml`, mirrored to `deploy/config-files/collector/values-daemonset.yaml`) — the three existing genai processors (copy-events-to-span, canonicalize-token-names, fix-token-counts) are **merged into a single `transform/genai_semconv` processor** with ordered stages, and a fourth stage added: per-operation Strands shaping, self-scoped on the `strands-agents` provider marker. Also ports prod's `exception.type → error.type` promotion to the local values. product-reviews/llm-evals paths are unchanged (stages 1–3 are byte-identical to the previous processors).

### Validation

Deployed to `martin-local` and driven with manual multi-turn conversations (order lookup → shipping → refund; loadgen disabled). Verified in Honeycomb (`otel-demo-local`):

- Per-operation attribute presence matrix matches the tables above exactly (zero stragglers).
- Token math exact: `input_tokens` 5937 = 921 uncached + 5016 cache_read + 0 cache_creation; `demo.gen_ai.usage.uncached_input_tokens` still feeds the SLI (now only on real model-call spans).
- `span.num_events = 0` on all Strands spans.
- Full trace hierarchy intact: `POST /chat` → supervisor → sub-agents → tools → `shipping` service.
- Collector config (including the post-rebase merged transform) validated offline with `latest-collector validate --config`.

### Known upstream gaps (documented, not fixable here)

- Strands doesn't expose `gen_ai.response.model` / `gen_ai.response.id`.
- The provider hardcoding is worth an issue against `strands-agents/sdk-python` — `BedrockModel` knows the real provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
